### PR TITLE
fix: homepage links

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,48 +6,62 @@ subtitle: An Open Source .NET Library for RDF
 
 <article>
     <section>
-    <header>
-        <h1>dotNetRDF is...</h1>
-    </header>
-    <ul>
-        <li>A complete library for <a hreef="https://www.dotnetrdf.org/docs/stable/user_guide/Reading-RDF.html">parsing</a>, <a href="https://www.dotnetrdf.org/docs/stable/user_guide/Working-With-Graphs.html">managing</a>, <a href="https://www.dotnetrdf.org/docs/stable/user_guide/Querying-With-SPARQL.html">querying</a> and <a href="https://www.dotnetrdf.org/docs/stable/user_guide/Writing-RDF.html">writing</a> RDF.</li>
+        <header>
+            <h1>dotNetRDF is...</h1>
+        </header>
+        <ul>
+            <li>A complete library for <a
+                    href="https://dotnetrdf.org/docs/stable/user_guide/reading_rdf.html">parsing</a>, <a
+                    href="https://dotnetrdf.org/docs/stable/user_guide/working_with_graphs.html">managing</a>, <a
+                    href="https://dotnetrdf.org/docs/stable/user_guide/querying_with_sparql.html">querying</a> and
+                <a href="https://dotnetrdf.org/docs/stable/user_guide/writing_rdf.html">writing</a> RDF.
+            </li>
 
-        <li>A common .NET API for <a href="https://www.dotnetrdf.org/docs/stable/user_guide/Working-With-Triple-Stores.html">working with RDF triple stores</a> such as AllegroGraph, Jena, Stardog and Virtuoso.</li>
+            <li>A common .NET API for <a
+                    href="https://dotnetrdf.org/docs/stable/user_guide/working_with_triple_stores.html">working with
+                    RDF triple stores</a> such as AllegroGraph, Jena, Stardog and Virtuoso.</li>
 
-        <li>A suite of <a href="https://www.dotnetrdf.org/docs/stable/user_guide/Tools.html">command-line and GUI tools</a> for working with RDF under Windows</li>
-    
-        <li>Free (as in beer) and Open Source (as in freedom) under a permissive MIT license.</li>
-    </ul>
+            <li>Free (as in beer) and Open Source (as in freedom) under a permissive MIT license.</li>
+        </ul>
     </section>
-    <section>
-        <header><h1>Get Started</h1></header>
-        
-        <p>The core library is available via <a href="https://www.nuget.org/packages?q=dotnetrdf">NuGet</a> - this is the easiest, and recommended way to add dotNetRDF to your project.
-        Our <a href="https://dotnetrdf.org/docs/stable/user_guide/getting_started.html">Getting Started Guide</a> will take you through writing your first lines of code.</p>
-
-    </section>
-    <section>
-        <header><h1>Join In</h1></header>
-
-        <p>Our source code is <a href="http://github.com/dotnetrdf/dotnetrdf">on GitHub</a>. 
-		If you have a question please raise it on <a href="https://stackoverflow.com/questions/tagged/dotnetrdf">StackOverflow with the <emph>dotnetrdf</emph> tag</a>.
-        If you find an issue you can fix, feel free to fork our repository and submit a pull request.
-        If you find a problem you can't fix, you can report it on the <a href="http://github.com/dotnetrdf/dotnetrdf/issues">issue tracker</a>.</p>
-    </section>
-    
     <section>
         <header>
-			<h1 class="logo-black">From the Blog</h1>
-		</header>
-				<div class="row">
-					{% for post in site.posts limit:2 %}
-						<div class="col-md-6">
-							<h3><a href="{{ post.url }}" title="{{ post.title }}">{{ post.title }}</a></h3>
-							<p><span class="small">{{ post.date | date_to_long_string }}</span></p>
-							{{ post.excerpt }}
-							<p class="text-right"><a href="{{ post.url }}" title="{{ post.title }}">Read More...</a></p>
-						</div>
-					{% endfor %}
-				</div>
+            <h1>Get Started</h1>
+        </header>
+
+        <p>The core library is available via <a href="https://www.nuget.org/profiles/dotnetrdf">NuGet</a> - this is
+            the easiest, and recommended way to add dotNetRDF to your project.
+            Our <a href="https://dotnetrdf.org/docs/stable/user_guide/getting_started.html">Getting Started Guide</a>
+            will take you through writing your first lines of code.</p>
+
+    </section>
+    <section>
+        <header>
+            <h1>Join In</h1>
+        </header>
+
+        <p>Our source code is <a href="http://github.com/dotnetrdf/dotnetrdf">on GitHub</a>.
+            If you have a question please raise it on <a
+                href="https://stackoverflow.com/questions/tagged/dotnetrdf">StackOverflow with the <emph>dotnetrdf
+                </emph> tag</a>.
+            If you find an issue you can fix, feel free to fork our repository and submit a pull request.
+            If you find a problem you can't fix, you can report it on the <a
+                href="http://github.com/dotnetrdf/dotnetrdf/issues">issue tracker</a>.</p>
+    </section>
+
+    <section>
+        <header>
+            <h1 class="logo-black">From the Blog</h1>
+        </header>
+        <div class="row">
+            {% for post in site.posts limit:2 %}
+            <div class="col-md-6">
+                <h3><a href="{{ post.url }}" title="{{ post.title }}">{{ post.title }}</a></h3>
+                <p><span class="small">{{ post.date | date_to_long_string }}</span></p>
+                {{ post.excerpt }}
+                <p class="text-right"><a href="{{ post.url }}" title="{{ post.title }}">Read More...</a></p>
+            </div>
+            {% endfor %}
+        </div>
     </section>
 </article>


### PR DESCRIPTION
Fixes:

- a href attr fixed on the first link (parsing) that made it non-clickable previously
- correct casing for the links into the stable user guide
- NuGet link points to the DotNetRDF org instead of searching for any packages mentioning DotNetRDF
- Tools link is removed (we could link to https://github.com/dotnetrdf/dotNetRDF.Toolkit instead but it seems like it's not actively maintained)

P.S. Formatting changes are from auto-format in VS Code.